### PR TITLE
Add MANIFEST to deal with defaults.yaml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/icecream/defaults.yaml


### PR DESCRIPTION
Hello :)

I wanted to install icecream with `pip install .` instead of `pip install -e .` to have a clear installation. However, I realized that the defaults.yaml does not get installed due to a missing MANIFEST.in file.

I added the file and thought: Why not contribute it to see if you also find it useful.

Best,
Markus